### PR TITLE
Add appointment placeholder for adoptions

### DIFF
--- a/frontend/src/pages/myAdoptions/css/myAdoptions.css
+++ b/frontend/src/pages/myAdoptions/css/myAdoptions.css
@@ -32,7 +32,8 @@
 }
 
 /* Button now comes before the tag, with thinner padding */
-.btn, button.btn {
+.btn,
+button.btn {
   margin-right: 10px;
   padding: 6px 12px;
   font-size: 0.9rem;
@@ -90,9 +91,43 @@
     text-align: center;
   }
 
-  .deposit-btn {
+  .appointment-btn {
     grid-area: btn;
     width: 100%;
     text-align: center;
   }
+}
+
+/* Appointment popup overlay */
+.appointment-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 1000;
+}
+
+.appointment-overlay .popup-content {
+  background-color: var(--container-background);
+  padding: 20px 30px;
+  border-radius: var(--border-radius);
+  max-width: 400px;
+  text-align: center;
+  position: relative;
+}
+
+.appointment-overlay .close-button {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 28px;
+  cursor: pointer;
 }

--- a/frontend/src/pages/myAdoptions/myAdoptions.html
+++ b/frontend/src/pages/myAdoptions/myAdoptions.html
@@ -24,5 +24,19 @@
       </section>
     </main>
     <div id="footer-placeholder"></div>
+    <div id="appointment-popup" class="appointment-overlay">
+      <div class="popup-content">
+        <button class="close-button" aria-label="Close">&times;</button>
+        <h2>Schedule Your Appointment</h2>
+        <p>
+          To complete your adoption, please call
+          <a href="tel:4068992633">(406) 899-2633</a> or email
+          <a href="mailto:reptileuniverse@yahoo.com"
+            >reptileuniverse@yahoo.com</a
+          >
+          to arrange an in-person appointment at our store.
+        </p>
+      </div>
+    </div>
   </body>
 </html>

--- a/frontend/src/pages/myAdoptions/scripts/loadApplications.js
+++ b/frontend/src/pages/myAdoptions/scripts/loadApplications.js
@@ -2,6 +2,26 @@ document.addEventListener("DOMContentLoaded", () => {
   const list = document.querySelector(".adoption-list");
   if (!list) return;
 
+  const popup = document.getElementById("appointment-popup");
+  const closeBtn = popup ? popup.querySelector(".close-button") : null;
+
+  function openPopup() {
+    if (popup) popup.style.display = "flex";
+  }
+
+  function closePopup() {
+    if (popup) popup.style.display = "none";
+  }
+
+  if (closeBtn) closeBtn.addEventListener("click", closePopup);
+
+  list.addEventListener("click", (e) => {
+    if (e.target.classList.contains("appointment-btn")) {
+      e.preventDefault();
+      openPopup();
+    }
+  });
+
   async function loadApps() {
     try {
       const [appRes, reptileRes] = await Promise.all([
@@ -43,9 +63,9 @@ document.addEventListener("DOMContentLoaded", () => {
       let buttonHTML = "";
 
       if (statusText === "approved" && pendingIds.has(app.reptile_id)) {
-        statusText = "awaiting deposit";
+        statusText = "appointment required";
         statusClass = "pending";
-        buttonHTML = `<button class="btn deposit-btn">Add Deposit</button>`;
+        buttonHTML = `<button class="btn appointment-btn">Schedule Appointment</button>`;
       }
 
       item.innerHTML = `


### PR DESCRIPTION
## Summary
- replace deposit language with an appointment instruction
- add schedule-appointment popup and styling
- hook up popup in adoption list script

## Testing
- `npm run lint`
- `npx prettier --write frontend/src/pages/myAdoptions/scripts/loadApplications.js frontend/src/pages/myAdoptions/css/myAdoptions.css frontend/src/pages/myAdoptions/myAdoptions.html`
- `npm run build:frontend`
- `npm start` in backend

------
https://chatgpt.com/codex/tasks/task_e_684a5785beb88328861f5229680acdae