### PR TITLE
Add admin file uploads

### DIFF
--- a/backend/src/models/animalFile.js
+++ b/backend/src/models/animalFile.js
@@ -1,0 +1,20 @@
+const { Model, DataTypes } = require("sequelize");
+const sequelize = require("../config/database");
+
+class AnimalFile extends Model {}
+
+AnimalFile.init(
+  {
+    reptile_id: { type: DataTypes.INTEGER, allowNull: false },
+    filename: { type: DataTypes.STRING, allowNull: false },
+    url: { type: DataTypes.STRING, allowNull: false },
+  },
+  {
+    sequelize,
+    modelName: "AnimalFile",
+    tableName: "animal_files",
+    timestamps: false,
+  },
+);
+
+module.exports = AnimalFile;

--- a/backend/src/routes/animalFiles.js
+++ b/backend/src/routes/animalFiles.js
@@ -1,0 +1,65 @@
+const express = require("express");
+const router = express.Router();
+const AnimalFile = require("../models/animalFile");
+const multer = require("multer");
+const path = require("path");
+const fs = require("fs");
+
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, path.join(__dirname, "../uploads/"));
+  },
+  filename: function (req, file, cb) {
+    const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9);
+    const ext = path.extname(file.originalname);
+    cb(null, uniqueSuffix + ext);
+  },
+});
+
+const upload = multer({ storage });
+
+router.get("/:reptileId", async (req, res) => {
+  try {
+    const list = await AnimalFile.findAll({
+      where: { reptile_id: req.params.reptileId },
+      order: [["id", "DESC"]],
+    });
+    res.json(list);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/:reptileId", upload.array("files", 10), async (req, res) => {
+  try {
+    const rid = req.params.reptileId;
+    const created = [];
+    for (const f of req.files) {
+      const file = await AnimalFile.create({
+        reptile_id: rid,
+        filename: f.originalname,
+        url: `/uploads/${f.filename}`,
+      });
+      created.push(file);
+    }
+    res.status(201).json(created);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  try {
+    const file = await AnimalFile.findByPk(req.params.id);
+    if (!file) return res.status(404).json({ error: "Not found" });
+    const filename = file.url.split("/").pop();
+    const filepath = path.join(__dirname, "../uploads", filename);
+    await file.destroy();
+    fs.unlink(filepath, () => {});
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -103,6 +103,7 @@ const { RedisStore } = require("connect-redis");
   const surrenderRoutes = require("./routes/surrenders");
 
   const healthInspectionRoutes = require("./routes/healthInspections");
+  const animalFileRoutes = require("./routes/animalFiles");
   const adoptionAppRoutes = require("./routes/adoptionApps");
   const clientsRoutes = require("./routes/clients");
   const recoveryRoutes = require("./routes/accountRecovery");
@@ -114,6 +115,7 @@ const { RedisStore } = require("connect-redis");
   app.use("/api/adoptions", adoptionRoutes);
   app.use("/api/surrenders", surrenderRoutes);
   app.use("/api/health-inspections", healthInspectionRoutes);
+  app.use("/api/animal-files", animalFileRoutes);
   app.use("/api/adoption-apps", adoptionAppRoutes);
   app.use("/api/clients", clientsRoutes);
   app.use("/api/account-recovery", recoveryLimiter, recoveryRoutes);
@@ -132,6 +134,7 @@ const { RedisStore } = require("connect-redis");
   require("./models/adoption");
   require("./models/surrender");
   require("./models/healthInspection");
+  require("./models/animalFile");
   require("./models/adoptionApp");
 
   sequelize

--- a/frontend/src/pages/admin/admin.html
+++ b/frontend/src/pages/admin/admin.html
@@ -80,6 +80,7 @@
                 <th>Requirements</th>
                 <th class="inspection-header">Inspections</th>
                 <th>Images</th>
+                <th>Files</th>
                 <th>Update</th>
                 <th>Delete</th>
               </tr>
@@ -118,6 +119,7 @@
                 <th>Requirements</th>
                 <th class="inspection-header">Inspections</th>
                 <th>Images</th>
+                <th>Files</th>
                 <th>Update</th>
                 <th>Delete</th>
               </tr>

--- a/frontend/src/pages/admin/admin.js
+++ b/frontend/src/pages/admin/admin.js
@@ -8,4 +8,5 @@ import "./scripts/adminsTab.js";
 import "./scripts/pendingAdoptionsTab.js";
 import "./scripts/pendingPaymentsTab.js";
 import "./scripts/clientsTab.js";
+import "./scripts/filesPopup.js";
 import "../../scripts/ensureAdmin.js";

--- a/frontend/src/pages/admin/scripts/animalsTab.js
+++ b/frontend/src/pages/admin/scripts/animalsTab.js
@@ -52,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
         <td>${a.requirements || ""}</td>
         <td class="inspection-cell" data-id="${a.id}">...</td>
         <td>${(a.image_urls || []).join(", ")}</td>
+        <td><button class="files-btn btn-option">Files</button></td>
         <td><button class="edit-btn btn-option">Edit</button></td>
         <td><button class="delete-btn btn-option">Delete</button></td>`;
       tableBody.appendChild(row);
@@ -108,6 +109,8 @@ document.addEventListener("DOMContentLoaded", () => {
       deleteAnimal(id);
     } else if (e.target.classList.contains("inspection-cell")) {
       openInspectionPopup(id);
+    } else if (e.target.classList.contains("files-btn")) {
+      if (window.openFilesPopup) window.openFilesPopup(id);
     }
   });
 

--- a/frontend/src/pages/admin/scripts/clientsTab.js
+++ b/frontend/src/pages/admin/scripts/clientsTab.js
@@ -2,6 +2,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const tableBody = document.getElementById("clients-table-body");
   let clients = [];
 
+  tableBody.addEventListener("click", (e) => {
+    if (e.target.classList.contains("files-btn")) {
+      e.stopPropagation();
+      const id = e.target.dataset.id;
+      if (window.openFilesPopup) window.openFilesPopup(id);
+    }
+  });
+
   async function loadClients() {
     try {
       const res = await fetch("/api/clients");
@@ -78,9 +86,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!Array.isArray(list) || list.length === 0)
       return "<p>No animals owned.</p>";
     let html =
-      "<table class='owned-table'><thead><tr><th>Name</th><th>Species</th><th>Sex</th><th>Age</th><th>Traits</th></tr></thead><tbody>";
+      "<table class='owned-table'><thead><tr><th>Name</th><th>Species</th><th>Sex</th><th>Age</th><th>Traits</th><th>Files</th></tr></thead><tbody>";
     list.forEach((a) => {
-      html += `<tr><td>${a.name}</td><td>${a.species}</td><td>${a.sex || ""}</td><td>${a.age || ""}</td><td>${a.traits || ""}</td></tr>`;
+      html += `<tr><td>${a.name}</td><td>${a.species}</td><td>${a.sex || ""}</td><td>${a.age || ""}</td><td>${a.traits || ""}</td><td><button class='files-btn btn-option' data-id='${a.id}'>Files</button></td></tr>`;
     });
     html += "</tbody></table>";
     return html;

--- a/frontend/src/pages/admin/scripts/filesPopup.js
+++ b/frontend/src/pages/admin/scripts/filesPopup.js
@@ -1,0 +1,85 @@
+document.addEventListener("popupsLoaded", () => {
+  const container = document.getElementById("files-popup-container");
+  const listEl = document.getElementById("files-list");
+  const form = document.getElementById("files-form");
+  const input = document.getElementById("files-input");
+  if (!container) return;
+
+  async function loadList(id) {
+    listEl.innerHTML = "Loading...";
+    try {
+      const res = await fetch(`/api/animal-files/${id}`);
+      const files = res.ok ? await res.json() : [];
+      if (!files.length) {
+        listEl.textContent = "No files.";
+        return;
+      }
+      listEl.innerHTML = "";
+      files.forEach((f) => {
+        const div = document.createElement("div");
+        div.className = "file-item";
+        div.dataset.id = f.id;
+        let thumb;
+        if (f.url.match(/\.(png|jpe?g|gif)$/i)) {
+          thumb = document.createElement("img");
+          thumb.src = f.url;
+          thumb.className = "file-thumb";
+        } else {
+          thumb = document.createElement("div");
+          thumb.className = "file-thumb";
+          thumb.textContent = "DOC";
+          thumb.style.display = "flex";
+          thumb.style.alignItems = "center";
+          thumb.style.justifyContent = "center";
+          thumb.style.background = "#444";
+          thumb.style.color = "#fff";
+        }
+        div.appendChild(thumb);
+        const del = document.createElement("button");
+        del.textContent = "Delete";
+        del.className = "delete-file btn-option";
+        div.appendChild(del);
+        listEl.appendChild(div);
+      });
+    } catch (err) {
+      console.error(err);
+      listEl.textContent = "Error loading files.";
+    }
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const id = container.dataset.reptileId;
+    const fd = new FormData();
+    for (const file of input.files) fd.append("files", file);
+    await fetch(`/api/animal-files/${id}`, { method: "POST", body: fd });
+    input.value = "";
+    loadList(id);
+  });
+
+  listEl.addEventListener("click", async (e) => {
+    if (e.target.classList.contains("delete-file")) {
+      const id = e.target.parentElement.dataset.id;
+      await fetch(`/api/animal-files/${id}`, { method: "DELETE" });
+      loadList(container.dataset.reptileId);
+    } else if (e.target.classList.contains("file-thumb")) {
+      if (e.target.tagName === "IMG") {
+        window.open(e.target.src, "_blank");
+      } else {
+        const id = e.target.parentElement.dataset.id;
+        const f = await fetch(
+          `/api/animal-files/${container.dataset.reptileId}`,
+        )
+          .then((r) => r.json())
+          .then((arr) => arr.find((x) => String(x.id) === String(id)));
+        if (f) window.open(f.url, "_blank");
+      }
+    }
+  });
+
+  window.openFilesPopup = function (id) {
+    container.dataset.reptileId = id;
+    loadList(id);
+    container.style.display = "flex";
+  };
+});

--- a/frontend/src/pages/admin/scripts/forSaleTab.js
+++ b/frontend/src/pages/admin/scripts/forSaleTab.js
@@ -52,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
         <td>${a.requirements || ""}</td>
         <td class="inspection-cell" data-id="${a.id}">...</td>
         <td>${(a.image_urls || []).join(", ")}</td>
+        <td><button class="files-btn btn-option">Files</button></td>
         <td><button class="edit-btn btn-option">Edit</button></td>
         <td><button class="delete-btn btn-option">Delete</button></td>`;
       tableBody.appendChild(row);
@@ -108,6 +109,8 @@ document.addEventListener("DOMContentLoaded", () => {
       deleteAnimal(id);
     } else if (e.target.classList.contains("inspection-cell")) {
       openInspectionPopup(id);
+    } else if (e.target.classList.contains("files-btn")) {
+      if (window.openFilesPopup) window.openFilesPopup(id);
     }
   });
 
@@ -167,7 +170,8 @@ document.addEventListener("DOMContentLoaded", () => {
         for (const file of imagesInput.files) {
           formData.append("images", file);
         }
-        if (!editingId && statusField) formData.append("status", statusField.value);
+        if (!editingId && statusField)
+          formData.append("status", statusField.value);
 
         // ———————————————————————————————
         // 5c) Determine POST vs PUT & send

--- a/frontend/src/pages/popups/admin-animal-files-popup.html
+++ b/frontend/src/pages/popups/admin-animal-files-popup.html
@@ -1,0 +1,18 @@
+<!-- Popup for viewing and uploading animal files -->
+<div id="files-popup-container" class="popup-container">
+  <div class="popup-content">
+    <button class="close-button">&times;</button>
+    <h2>Animal Files</h2>
+    <div id="files-list" style="margin-bottom: 1em"></div>
+    <form id="files-form">
+      <input
+        type="file"
+        id="files-input"
+        name="files"
+        multiple
+        accept="image/*,.pdf,.doc,.docx,.txt"
+      />
+      <button type="submit" class="btn-option">Upload</button>
+    </form>
+  </div>
+</div>

--- a/frontend/src/pages/popups/css/popup.css
+++ b/frontend/src/pages/popups/css/popup.css
@@ -48,12 +48,12 @@
 
 /* Style for the images in the popup options */
 .option-image {
-  width: 40%;           /* Adjusts the width to 80% of the container */
-  height: auto;         /* Maintains aspect ratio */
+  width: 40%; /* Adjusts the width to 80% of the container */
+  height: auto; /* Maintains aspect ratio */
   border-radius: 50% / 25%; /* Creates the oval shape */
   margin-bottom: 15px;
-  object-fit: contain;  /* Ensures the entire image is visible */
-  display: block;       /* Centers the image horizontally */
+  object-fit: contain; /* Ensures the entire image is visible */
+  display: block; /* Centers the image horizontally */
   margin-left: auto;
   margin-right: auto;
 }
@@ -120,6 +120,21 @@
 
 .popup-options .btn-option:hover {
   background-color: #ff5a4d;
+}
+
+.file-item {
+  display: inline-block;
+  margin: 5px;
+  text-align: center;
+}
+
+.file-thumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  cursor: pointer;
+  display: block;
+  margin-bottom: 3px;
 }
 
 /* Responsive Design */

--- a/frontend/src/pages/popups/scripts/popupInitilzation.js
+++ b/frontend/src/pages/popups/scripts/popupInitilzation.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
     "admin-adoption-app-popup.html",
     "admin-add-admin-popup.html",
     "deposit-notice-popup.html",
+    "admin-animal-files-popup.html",
   ];
   let loadedPopupsCount = 0;
 


### PR DESCRIPTION
## Summary
- allow admins to attach files to animals
- display Files column on adoption and for-sale tables
- manage animal files through a new popup
- show file button for owned animals
- expose API routes and model for animal files

## Testing
- `npm run lint`
- `npm run format`
- `npm run build:frontend`
- `npm run start:backend` *(fails: SESSION_SECRET missing)*

------
https://chatgpt.com/codex/tasks/task_e_686551a84f208328b1bb823b1d56865a